### PR TITLE
Add shields at the top for quick navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # maplibre-vscode-extension
 
-<https://marketplace.visualstudio.com/items?itemName=kiguchi.maplibre-vscode-extension>
+[![GitHub](https://img.shields.io/badge/github-maplibre--vscode--extension-8da0cb?logo=github)](https://github.com/Kanahiro/maplibre-vscode-extension)
+[![Visual Studio Marketplace Downloads](https://img.shields.io/visual-studio-marketplace/d/kiguchi.maplibre-vscode-extension)](https://marketplace.visualstudio.com/items?itemName=kiguchi.maplibre-vscode-extension)
+[![Visual Studio Marketplace Installs](https://img.shields.io/visual-studio-marketplace/i/kiguchi.maplibre-vscode-extension)](https://marketplace.visualstudio.com/items?itemName=kiguchi.maplibre-vscode-extension)
+[![Visual Studio Marketplace Rating](https://img.shields.io/visual-studio-marketplace/stars/kiguchi.maplibre-vscode-extension)](https://marketplace.visualstudio.com/items?itemName=kiguchi.maplibre-vscode-extension)
 
 ## Usage
 


### PR DESCRIPTION
I am not too familiar with VSCode marketplace, but it seems the [extension page](https://marketplace.visualstudio.com/items?itemName=kiguchi.maplibre-vscode-extension&ssr=false#overview) does not link to this repo (I had to search slack messages).  So updating it to link to both github and to the marketplace as shields